### PR TITLE
feat(obsidian): add daily context extraction controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ The Obsidian command palette exposes:
 
 - **Visual Notes: Extract from current note** — manually extract the active
   markdown file unless its sidecar is pinned.
+- **Visual Notes: Extract from current note using Daily Context** — manually
+  extract through the Daily Context provider and do not fall back to raw
+  markdown if that provider is unavailable.
 - **Visual Notes: Regenerate (force)** — bypasses cached hash and pin state,
   with a per-file cooldown.
 - **Visual Notes: Pin this overview** — preserves the current sidecar from
@@ -188,9 +191,9 @@ The Obsidian command palette exposes:
 
 ## Privacy and cost
 
-Visual Notes sends the **full markdown content** of watched notes to the
-Anthropic API when extraction runs. Do not add folders containing notes you do
-not want sent to a third-party API.
+Visual Notes sends either the configured Daily Context sources or the active
+note markdown to the Anthropic API when extraction runs. Do not add folders or
+Daily Context sources containing notes you do not want sent to a third-party API.
 
 Bring your own API key; this project does not proxy requests or aggregate
 usage. At the default Haiku model, a typical extraction is designed to cost

--- a/plugins/obsidian-plugin/README.md
+++ b/plugins/obsidian-plugin/README.md
@@ -70,6 +70,7 @@ After install, open Settings → Visual Notes:
 | **Watched folders** | A list of folders containing daily notes. **Empty by default** — add at least one for the plugin to do anything. Subfolders are searched recursively. Add multiple folders if you keep separate work/personal/project journals (e.g., `Captains Log`, `0 Daily ADHD Brain Logs`, `Projects/visual-notes/Journal`). Each folder produces its own sidecars in-place; same model, same prompt, same schema across all watched folders. |
 | **Debounce (ms)** | How long to wait after the last save before extracting. Default: 1500ms. |
 | **Model** | `claude-haiku-4-5` (default, ~$0.006/extraction) or `claude-sonnet-4-6` (~$0.02). |
+| **Use Daily Context** | When the `daily-context` plugin is available, extract from structured daily sources instead of raw note markdown. |
 
 Custom prompt override is **not exposed in v0.1** — the bundled extraction
 prompt at `prompts/extract-graph.md` is the canonical heuristic source.
@@ -108,7 +109,12 @@ Bring your own API key. The plugin does not proxy or aggregate usage.
 
 ## Sources of content
 
-The plugin sees **everything** in the daily note:
+By default, the plugin extracts from the active note. When Daily Context is
+enabled and available, it extracts from that provider's structured source list
+instead. The explicit **Extract from current note using Daily Context** command
+requires the provider and does not fall back to raw markdown.
+
+Raw-note mode sees **everything** in the daily note:
 - AI session summaries written by Claude Code, OpenCode, Copilot, etc.
 - Manually typed notes
 - Mobile edits synced via Obsidian Sync
@@ -119,11 +125,11 @@ If it's in the file, the LLM extraction sees it.
 
 ## Privacy / data handling
 
-The plugin sends the **full markdown content** of the daily note to Anthropic's
-API for extraction. By default, your notes do not stay on Anthropic's servers
-beyond what's required for the API call (see [Anthropic's privacy policy](https://www.anthropic.com/legal/privacy)).
-Sensitive notes you don't want sent to a third-party API should not live
-in any watched folder.
+The plugin sends either Daily Context source content or raw note markdown to
+Anthropic's API for extraction. By default, your notes do not stay on Anthropic's
+servers beyond what's required for the API call (see [Anthropic's privacy policy](https://www.anthropic.com/legal/privacy)).
+Sensitive notes you don't want sent to a third-party API should not live in any
+watched folder or Daily Context source.
 
 ## License
 

--- a/plugins/obsidian-plugin/src/main.ts
+++ b/plugins/obsidian-plugin/src/main.ts
@@ -48,6 +48,7 @@ type VisualNotesViewMode = "preview" | "source";
 interface ExtractionOptions {
   force: boolean;
   manual: boolean;
+  sourceMode?: "auto" | "daily-context";
 }
 
 interface PreparedExtractionInput {
@@ -181,6 +182,14 @@ export default class VisualNotesPlugin extends Plugin {
       name: "Extract from current note",
       checkCallback: (checking) => this.withActiveMarkdownFile(checking, (file) =>
         this.extractFile(file, { force: false, manual: true }),
+      ),
+    });
+
+    this.addCommand({
+      id: "extract-current-note-daily-context",
+      name: "Extract from current note using Daily Context",
+      checkCallback: (checking) => this.withDailyContextMarkdownFile(checking, (file) =>
+        this.extractFile(file, { force: false, manual: true, sourceMode: "daily-context" }),
       ),
     });
 
@@ -345,6 +354,38 @@ export default class VisualNotesPlugin extends Plugin {
     return true;
   }
 
+  private withDailyContextMarkdownFile(
+    checking: boolean,
+    callback: (file: TFile) => Promise<void>,
+  ): boolean {
+    const file = this.app.workspace.getActiveFile();
+    const isMarkdown = file instanceof TFile && file.extension === "md";
+    const hasDailyContext = getDailyContextApi(this.app) !== null;
+    const hasDate = isMarkdown ? normalizeDailyContextDateFromPath(file.path) !== null : false;
+
+    if (checking) {
+      return isMarkdown && hasDailyContext && hasDate;
+    }
+
+    if (!isMarkdown) {
+      new Notice("Visual Notes: open a markdown daily note first.");
+      return false;
+    }
+
+    if (!hasDailyContext) {
+      new Notice("Visual Notes: Daily Context plugin API is not available.");
+      return false;
+    }
+
+    if (!hasDate) {
+      new Notice("Visual Notes: current note name does not contain a Daily Context date.");
+      return false;
+    }
+
+    void callback(file);
+    return true;
+  }
+
   private queueExtraction(file: TFile): void {
     const existing = this.debounceTimers.get(file.path);
     existing?.cancel();
@@ -388,7 +429,10 @@ export default class VisualNotesPlugin extends Plugin {
 
     try {
       const rawMarkdown = await this.app.vault.read(file);
-      const extractionInput = await this.prepareExtractionInput(file, rawMarkdown);
+      const extractionInput = await this.prepareExtractionInput(file, rawMarkdown, options);
+      if (!extractionInput) {
+        return;
+      }
       const estimatedTokens = estimateTokens(extractionInput.markdown);
       if (estimatedTokens > MAX_INPUT_TOKENS) {
         new Notice(`Visual Notes: note is too large to extract (${estimatedTokens} estimated tokens).`);
@@ -498,14 +542,22 @@ export default class VisualNotesPlugin extends Plugin {
     }
   }
 
-  private async prepareExtractionInput(file: TFile, rawMarkdown: string): Promise<PreparedExtractionInput> {
+  private async prepareExtractionInput(
+    file: TFile,
+    rawMarkdown: string,
+    options: ExtractionOptions,
+  ): Promise<PreparedExtractionInput | null> {
     const rawHash = await sha256Hash(rawMarkdown);
-    const dailyContext = await this.prepareDailyContextExtraction(file);
+    const dailyContext = await this.prepareDailyContextExtraction(file, options.sourceMode ?? "auto");
     if (dailyContext) {
       return {
         ...dailyContext,
         rawHash,
       };
+    }
+
+    if (options.sourceMode === "daily-context") {
+      return null;
     }
 
     const [semanticHash, sections] = await Promise.all([
@@ -522,18 +574,28 @@ export default class VisualNotesPlugin extends Plugin {
     };
   }
 
-  private async prepareDailyContextExtraction(file: TFile): Promise<PreparedDailyContextExtraction | null> {
-    if (!this.settings.useDailyContext) {
+  private async prepareDailyContextExtraction(
+    file: TFile,
+    sourceMode: "auto" | "daily-context",
+  ): Promise<PreparedDailyContextExtraction | null> {
+    const requiresDailyContext = sourceMode === "daily-context";
+    if (sourceMode === "auto" && !this.settings.useDailyContext) {
       return null;
     }
 
     const api = getDailyContextApi(this.app);
     if (!api) {
+      if (requiresDailyContext) {
+        new Notice("Visual Notes: Daily Context plugin API is not available.");
+      }
       return null;
     }
 
     const date = normalizeDailyContextDateFromPath(file.path);
     if (!date) {
+      if (requiresDailyContext) {
+        new Notice("Visual Notes: current note name does not contain a Daily Context date.");
+      }
       return null;
     }
 
@@ -542,10 +604,18 @@ export default class VisualNotesPlugin extends Plugin {
         dailyPath: file.path,
         contextId: this.settings.dailyContextId || undefined,
       });
-      return buildDailyContextExtractionInput(context);
+      const extractionInput = buildDailyContextExtractionInput(context);
+      if (!extractionInput && requiresDailyContext) {
+        new Notice("Visual Notes: Daily Context returned no usable source content.");
+      }
+      return extractionInput;
     } catch (error) {
       this.log("warn", "Daily Context extraction source failed; falling back to raw note.", error);
-      new Notice("Visual Notes: Daily Context failed; falling back to raw note. See console.");
+      new Notice(
+        requiresDailyContext
+          ? "Visual Notes: Daily Context extraction failed. See console."
+          : "Visual Notes: Daily Context failed; falling back to raw note. See console.",
+      );
       return null;
     }
   }

--- a/plugins/obsidian-plugin/src/renderer.ts
+++ b/plugins/obsidian-plugin/src/renderer.ts
@@ -121,6 +121,11 @@ export class VisualNotesRenderChild extends MarkdownRenderChild {
     this.observeGraphSize(graphEl);
     this.scheduleRefitGraph();
 
+    this.containerEl.createDiv({
+      cls: "visual-notes-source",
+      text: formatSourceSummary(sidecar),
+    });
+
     if (sidecar._usage) {
       this.containerEl.createDiv({
         cls: "visual-notes-usage",
@@ -395,4 +400,17 @@ function formatUsd(value: number): string {
   }
 
   return `$${value.toFixed(2)}`;
+}
+
+function formatSourceSummary(sidecar: VisualNotesSidecar): string {
+  if (sidecar._sourceContext?.provider === "daily-context") {
+    const sourceCount = sidecar._sourceContext.sourceCount;
+    return `Source: Daily Context (${sourceCount} source${sourceCount === 1 ? "" : "s"})`;
+  }
+
+  if (sidecar._lastProcessedHashKind === "semantic-markdown") {
+    return "Source: raw markdown";
+  }
+
+  return "Source: unknown";
 }

--- a/plugins/obsidian-plugin/styles.css
+++ b/plugins/obsidian-plugin/styles.css
@@ -35,11 +35,17 @@
   margin-top: 0.25rem;
 }
 
+.visual-notes-source,
 .visual-notes-usage {
   border-top: 1px solid var(--background-modifier-border);
   padding: 0.5rem 1rem 0.65rem;
   color: var(--text-muted);
   font-size: var(--font-ui-smaller);
+}
+
+.visual-notes-source + .visual-notes-usage {
+  border-top: 0;
+  padding-top: 0;
 }
 
 .visual-notes-legend {


### PR DESCRIPTION
## Summary
- add an explicit Daily Context extraction command that requires the provider
- keep automatic mode fallback behavior unchanged
- show sidecar source metadata in the inline renderer
- document Daily Context command/privacy behavior

## Validation
- npm --prefix plugins/obsidian-plugin run test:feature
- npm --prefix plugins/obsidian-plugin run typecheck
- npm --prefix plugins/obsidian-plugin run validate:renderer
- npm --prefix plugins/obsidian-plugin run validate:layout
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm package:obsidian