### PR TITLE
test(obsidian): accept Daily Context schema v3

### DIFF
--- a/plugins/obsidian-plugin/src/daily-context.ts
+++ b/plugins/obsidian-plugin/src/daily-context.ts
@@ -37,7 +37,7 @@ export interface DailyContext {
 export interface DailyContextGroup {
   id: string;
   dailyFolder: string;
-  sessionFolder: string;
+  aiSessionFolders: string[];
 }
 
 export interface DailyContextSource {

--- a/plugins/obsidian-plugin/test/feature/daily-context.test.ts
+++ b/plugins/obsidian-plugin/test/feature/daily-context.test.ts
@@ -104,7 +104,7 @@ test("buildDailyContextExtractionInput consumes representative fixture output", 
   assert.equal(extraction.processedHash, fixture.contextHash);
   assert.equal(extraction.processedHashKind, "daily-context");
   assert.equal(extraction.sourceContext.provider, "daily-context");
-  assert.equal(extraction.sourceContext.schemaVersion, 2);
+  assert.equal(extraction.sourceContext.schemaVersion, 3);
   assert.equal(extraction.sourceContext.sourceCount, 3);
   assert.deepEqual(
     extraction.sections.map((section) => section.id),
@@ -193,13 +193,13 @@ test("isExtractionCurrent compares processed hashes by source kind and preserves
 
 function dailyContext(overrides: Partial<DailyContext> = {}): DailyContext {
   return {
-    schemaVersion: 1,
+    schemaVersion: 3,
     parserVersion: 1,
     generatedAt: "2026-05-11T21:00:00.000Z",
     date: "2026-05-11",
     dateTag: "date/2026/05/11",
     contextHash: HASH_A,
-    contexts: [{ id: "personal", dailyFolder: "0 Daily ADHD Brain Logs", sessionFolder: "0 AI Sessions" }],
+    contexts: [{ id: "personal", dailyFolder: "0 Daily ADHD Brain Logs", aiSessionFolders: ["0 AI Sessions"] }],
     sources: [],
     ...overrides,
   };

--- a/plugins/obsidian-plugin/test/fixtures/daily-context/generic-context.json
+++ b/plugins/obsidian-plugin/test/fixtures/daily-context/generic-context.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "parserVersion": 2,
   "generatedAt": "2026-05-11T12:00:00.000Z",
   "date": "2026-05-11",
@@ -10,7 +10,7 @@
     {
       "id": "journal",
       "dailyFolder": "Journal",
-      "sessionFolder": "Sessions"
+      "aiSessionFolders": ["Sessions"]
     }
   ],
   "sources": [


### PR DESCRIPTION
## Summary
- update Visual Notes Daily Context consumer type to `aiSessionFolders`
- update representative fixture to schema v3
- keep adapter tests aligned with Daily Context output

## Validation
- npm --prefix plugins/obsidian-plugin run test:feature
- npm --prefix plugins/obsidian-plugin run typecheck
- npm --prefix plugins/obsidian-plugin run build