### PR TITLE
feat(obsidian): codeblock processor + legacy auto-mount removal (closes #24, supersedes #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Visual Notes
 
-> Turn an Obsidian daily note into a living concept map.
+> Turn Obsidian notes and AI session summaries into living concept maps.
 
-Visual Notes watches the markdown files you already use for daily notes,
-asks Claude to extract the main concepts and relationships, and renders an
+Visual Notes watches configured markdown folders, asks Claude to extract the
+main concepts and relationships, writes a JSON graph sidecar, and renders an
 interactive Cytoscape.js graph directly inside Obsidian.
 
-The markdown note stays the source of truth. Manual notes, AI session
-summaries, mobile edits, Templater output, and synced changes all flow
-through the same pipeline: if it lands in a watched note, it can appear in
-the visual.
+The markdown note stays the source of truth. Daily notes, AI session summaries,
+manual notes, mobile edits, Templater output, and synced changes all flow
+through the same plugin pipeline: if a watched note changes, it can be extracted
+and rendered.
 
 ## Why it is useful
 
@@ -22,54 +22,124 @@ the visual.
 - **Useful for memory and navigation:** nodes summarize important concepts;
   labeled edges explain why they matter.
 
-## What it does
+## Standalone capabilities
 
 ```mermaid
-flowchart LR
+flowchart TB
     classDef input fill:#eef2ff,stroke:#4f46e5,stroke-width:2px,color:#111827
     classDef plugin fill:#ecfeff,stroke:#0891b2,stroke-width:2px,color:#0f172a
     classDef ai fill:#fef3c7,stroke:#d97706,stroke-width:2px,color:#111827
     classDef data fill:#f0fdf4,stroke:#16a34a,stroke-width:2px,color:#052e16
     classDef render fill:#fae8ff,stroke:#c026d3,stroke-width:2px,color:#111827
-    classDef future fill:#f8fafc,stroke:#94a3b8,stroke-width:1px,stroke-dasharray: 5,5,color:#334155
+    classDef optional fill:#fff7ed,stroke:#ea580c,stroke-width:2px,stroke-dasharray: 5,5,color:#111827
 
-    subgraph Sources["Everyday note inputs"]
-        Manual["Manual notes"]
-        Sessions["AI session summaries"]
-        Mobile["Mobile edits"]
-        Templates["Templates and automations"]
+    subgraph Vault["Obsidian vault"]
+        Note[("Any watched markdown note")]
+        Sidecar[("Sibling graph sidecar<br/>{note-basename}-overview.json")]
     end
-
-    Note[("Watched daily note<br/>YYYYMMDD.md")]
 
     subgraph Plugin["Visual Notes Obsidian plugin"]
         Watch["Watch + debounce"]
-        Hash["Hash unchanged notes"]
-        Extract["Extract graph"]
+        Source["Choose source<br/>raw note by default"]
+        Hash["Hash + skip unchanged"]
+        Extract["Extract graph with Claude"]
         Validate["Validate schema"]
         Render["Render inline"]
     end
 
+    DailyContext["Optional Daily Context provider<br/>structured day sources"]
+    DateTags["Optional Date Tags provider<br/>date tag convention/API"]
     Claude(("Anthropic Claude"))
-    Sidecar[("Graph sidecar<br/>YYYYMMDD-overview.json")]
-    Pane["Interactive Cytoscape map<br/>inside the note"]
-    Future["Future: section-aware<br/>idempotent updates"]
+    Pane["Interactive Cytoscape visual<br/>inside the note"]
 
-    Manual --> Note
-    Sessions --> Note
-    Mobile --> Note
-    Templates --> Note
-    Note --> Watch --> Hash --> Extract --> Claude
+    Note --> Watch
+    DateTags -. can feed .-> DailyContext
+    DailyContext -. optional source adapter .-> Source
+    Watch --> Source --> Hash --> Extract --> Claude
     Claude --> Validate --> Sidecar --> Render --> Pane
-    Pane -. displayed above note content .-> Note
-    Future -. planned evolution .-> Hash
+    Sidecar -. read by .-> Render
+    Pane -. rendered in .-> Note
 
-    class Manual,Sessions,Mobile,Templates,Note input
-    class Watch,Hash,Extract,Validate,Render plugin
+    class Note input
+    class Watch,Source,Hash,Extract,Validate,Render plugin
     class Claude ai
     class Sidecar data
     class Pane render
-    class Future future
+    class DateTags,DailyContext optional
+```
+
+Visual Notes is useful by itself: configure any folder of markdown notes, provide
+an Anthropic key, and it can extract/render a graph for those notes. Daily
+Context and Date Tags are optional providers/adapters, not required runtime
+dependencies.
+
+| Component | Standalone responsibility | Optional integrations |
+|---|---|---|
+| Visual Notes plugin | Watches markdown, calls Claude, writes graph sidecars, renders Cytoscape inline. | Can consume Daily Context when present; can render explicit `visual-notes` blocks in templates. |
+| Daily Context plugin | Exposes structured date-scoped source lists through a versioned Obsidian API. | Can use Date Tags as its date-tag provider; can be consumed by Visual Notes or any other plugin/automation. |
+| Date Tags plugin | Maintains created/modified metadata and date tags. | Can provide tag-building semantics to Daily Context. |
+| AI session summary skill/template | Not part of the public plugin core; an integration recipe that writes ordinary markdown notes Visual Notes can watch. | Useful for AI-client session logging, but Visual Notes does not require it. |
+
+## Optional integration: AI session summaries
+
+One useful composition is AI session logging. In that workflow an AI-client skill
+creates an ordinary markdown session note from a vault template, then Visual
+Notes treats it like any other watched note.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Skill as obsidian-notes skill
+    participant Vault as Obsidian vault
+    participant VN as Visual Notes plugin
+    participant Claude as Anthropic Claude
+
+    User->>Skill: "make/end session summary"
+    Skill->>Vault: write AI session note from template
+    Vault-->>VN: watched session note modified
+    VN->>VN: raw-note extraction for non-date-named note
+    VN->>Claude: graph extraction request
+    Claude-->>VN: tool JSON graph
+    VN->>Vault: write session-overview.json
+    VN-->>User: render graph in visual-notes block
+```
+
+The template is an adapter detail, not a Visual Notes dependency. A good
+AI-session template can include:
+
+````markdown
+> [!summary] Session Summary
+> One-line summary.
+
+## Session Visual
+
+```visual-notes
+```
+
+## 2026-05-17
+````
+
+If you also use Date Tags/Daily Context, associate the session with a day via an
+explicit `date/YYYY/MM/DD` tag instead of adding a `[[YYYYMMDD]]` daily-note
+wikilink in the body.
+
+## Optional integration: daily overviews
+
+```mermaid
+sequenceDiagram
+    participant Daily as Daily note
+    participant DC as Daily Context
+    participant DT as Date Tags
+    participant VN as Visual Notes
+    participant Claude as Anthropic Claude
+
+    DT-->>DC: date tag convention/API
+    Daily->>VN: watched daily note modified or manual extract
+    VN->>DC: getDailyContext(date, include sources)
+    DC-->>VN: daily sections + AI session sources
+    VN->>Claude: graph extraction request
+    Claude-->>VN: tool JSON graph
+    VN->>Daily: render daily overview sidecar inline
 ```
 
 ## What it looks like in Obsidian
@@ -81,14 +151,16 @@ views. The graph is interactive; the note remains normal markdown underneath.
 
 Feature overview:
 
-- Watches one or more configured daily-note folders.
+- Watches one or more configured markdown folders, including daily-note folders
+  and AI session folders.
 - Debounces saves and skips unchanged content using a markdown hash.
-- Sends structured Daily Context sources to the Anthropic Messages API when
-  the `daily-context` plugin is available, otherwise falls back to full note
-  markdown.
+- Sends structured Daily Context sources to the Anthropic Messages API for
+  date-named daily notes when the `daily-context` plugin is available,
+  otherwise falls back to full note markdown.
 - Validates the returned graph against the shared sidecar schema.
-- Writes `{date}-overview.json` next to the note.
-- Renders the sidecar inline in reading and source views.
+- Writes `{note-basename}-overview.json` next to the note.
+- Renders the sidecar inline in reading/source views or in an explicit
+  `visual-notes` code block.
 - Supports pin/unpin/delete/regenerate commands for manual control.
 - Shows extraction count and status in the Obsidian status bar.
 - Tracks token usage and estimated cost metadata in the sidecar when the API
@@ -101,24 +173,33 @@ This repository contains two plugins and one shared schema:
 | Piece | Purpose | Status |
 |---|---|---|
 | [`plugins/obsidian-plugin`](plugins/obsidian-plugin/README.md) | Primary Obsidian plugin. Watches notes, calls Claude, writes sidecars, and renders Cytoscape inline. | MVP implementation in progress |
-| [`plugins/claude-code-plugin`](plugins/claude-code-plugin/README.md) | Optional companion for agent-curated sidecars after AI session summaries. | Scaffolded; migration pending |
+| [`plugins/claude-code-plugin`](plugins/claude-code-plugin/README.md) | Optional companion for future agent-curated sidecars. Not required for automatic extraction. | Scaffolded; migration pending |
 | [`shared/schema.json`](shared/schema.json) | JSON Schema contract for sidecar graph files. | Defined |
 | [`docs/design.md`](docs/design.md) | Living design document for open/future work. | Maintained as decisions evolve |
 
-The Obsidian plugin is the main product. The Claude Code plugin is optional:
-it can pre-populate or pin curated sidecars, but Visual Notes does not depend
-on Claude Code.
+The Obsidian plugin is the standalone product. The Claude Code companion is an
+optional adapter: it can eventually pre-populate or pin curated sidecars, but
+Visual Notes does not depend on any AI-client plugin or skill.
 
-## Architecture at a glance
+## File layout at a glance
 
 ```text
-Daily note folder
-├── 20260501.md              # source markdown
-└── 20260501-overview.json   # generated graph sidecar
+Any watched folder/
+├── note.md
+└── note-overview.json
+
+Daily folder example/
+├── 20260517.md
+└── 20260517-overview.json
+
+AI session folder example/
+└── 2026-05-17 plugin workflow/
+    ├── 2026-05-17 plugin workflow.md
+    └── 2026-05-17 plugin workflow-overview.json
 
 Obsidian plugin
 ├── settings tab             # API key, watched folders, debounce, model, Daily Context
-├── file watcher             # only watched markdown files
+├── file watcher             # configured markdown folders
 ├── extractor                # requestUrl -> Anthropic Messages API
 ├── schema validation        # Zod + shared/schema.json
 └── renderer                 # Cytoscape in MarkdownRenderChild
@@ -126,14 +207,15 @@ Obsidian plugin
 
 Important invariants:
 
-1. The `.md` note is read-only input for the plugin.
+1. The `.md` note is the source of truth for extraction.
 2. The sidecar JSON is the source of truth for rendered graph data.
 3. `_pinned: true` on a sidecar suppresses automatic re-extraction unless the
    user runs force regenerate.
 4. The renderer tolerates unsupported future sidecar kinds by showing a
    placeholder instead of crashing.
-5. Daily Context integration is optional; direct markdown extraction remains the
-   fallback when the provider is unavailable or not applicable to a note.
+5. Daily Context integration is optional and applies automatically only to
+   date-named daily notes. Other watched markdown files extract from their own
+   content, so non-daily workflows stay standalone.
 
 ## Install and setup
 
@@ -154,7 +236,8 @@ After enabling:
 
 1. Open **Settings → Visual Notes**.
 2. Paste an Anthropic API key.
-3. Add at least one watched folder, such as `Daily Notes` or `Captains Log`.
+3. Add watched folders, such as `Daily Notes`, `Captains Log`, `0 AI Sessions`,
+   or `0 Profisee/AI Sessions`.
 4. Choose a debounce and model, or keep the defaults.
 5. Save or manually extract a note with
    **Visual Notes: Extract from current note**.

--- a/docs/design.md
+++ b/docs/design.md
@@ -36,8 +36,10 @@ The Obsidian plugin has an MVP implementation:
 - sidecar writes stamped with producer/schema/hash/pin/usage metadata
 - optional `daily-context` provider support that extracts from structured daily
   sources and stamps `_sourceContext` metadata
-- `type: ai-session` notes bypass Daily Context in automatic mode so session
-  visuals are based on the session summary itself
+- Daily Context auto-mode is gated on the note's *filename* — only basenames
+  matching `YYYY-MM-DD.md` or `YYYYMMDD.md` qualify, so AI session summaries
+  (and any non-date-named note) implicitly bypass Daily Context and extract
+  from the note body itself
 - explicit `visual-notes` code blocks can reserve a persistent visual slot in
   AI session summary templates
 - inline Cytoscape rendering in Obsidian

--- a/docs/design.md
+++ b/docs/design.md
@@ -15,7 +15,7 @@ These are the constraints future changes should not casually break:
 1. **Markdown remains the universal input.** The Obsidian plugin reacts to
    watched `.md` files and does not require a specific AI client.
 2. **The plugin does not modify note markdown.** It reads notes and writes a
-   sibling sidecar (`{date}-overview.json`) only.
+   sibling sidecar (`{note-basename}-overview.json`) only.
 3. **The sidecar is the render contract.** The renderer consumes
    `shared/schema.json`; optional producers may write the same schema.
 4. **Every edge label carries meaning.** A graph with unlabeled or generic
@@ -36,13 +36,18 @@ The Obsidian plugin has an MVP implementation:
 - sidecar writes stamped with producer/schema/hash/pin/usage metadata
 - optional `daily-context` provider support that extracts from structured daily
   sources and stamps `_sourceContext` metadata
+- `type: ai-session` notes bypass Daily Context in automatic mode so session
+  visuals are based on the session summary itself
+- explicit `visual-notes` code blocks can reserve a persistent visual slot in
+  AI session summary templates
 - inline Cytoscape rendering in Obsidian
 - status bar extraction count
 - command palette controls for extract, force-regenerate, pin, unpin, and
   delete sidecar
 
-The Claude Code plugin remains scaffolded. Its full hook/skill migration is
-future work.
+The Claude Code plugin remains scaffolded. The normal session-summary trigger
+currently lives in the external `obsidian-notes` skill; the companion plugin is
+only for future agent-curated sidecar workflows.
 
 ## Remaining design work
 

--- a/plugins/claude-code-plugin/README.md
+++ b/plugins/claude-code-plugin/README.md
@@ -1,18 +1,20 @@
 # Visual Notes — Claude Code plugin
 
-Companion plugin for the Visual Notes concept-map system. Provides:
+Optional companion plugin for the Visual Notes concept-map system. It is not the
+normal session-summary trigger. The current trigger is an AI-client
+`obsidian-notes` skill that writes an AI session summary markdown document from
+the agreed template; the Obsidian Visual Notes plugin then extracts and renders
+the visual.
 
-- A **PostToolUse hook** on `obsidian append` that nudges agents to update the
-  daily-overview visual after writing session summaries.
-- A **`visual-notes` skill** that documents the sidecar JSON schema and design
-  heuristics, so agents can produce well-structured graph data when they
-  pre-populate the sidecar.
+This companion plugin is reserved for future workflows where an agent
+deliberately curates or pins a graph sidecar instead of relying on automatic
+plugin extraction.
 
 The companion **Obsidian plugin** is the primary way to use Visual Notes (see
 [`../obsidian-plugin/README.md`](../obsidian-plugin/README.md)). This Claude Code
-plugin is **optional**: it's useful when you want agent-curated graph nodes
-for specific sessions, but the Obsidian plugin's auto-extraction handles the
-common case without it.
+plugin is **optional**: it may become useful when you want agent-curated graph
+nodes for specific sessions, but the Obsidian plugin's auto-extraction handles
+the common case without it.
 
 ## Status
 

--- a/plugins/claude-code-plugin/skills/visual-notes/SKILL.md
+++ b/plugins/claude-code-plugin/skills/visual-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: visual-notes
-description: Concept-map visualization for daily notes. Documents the sidecar JSON schema and design heuristics so agents can pre-populate the visual when appending session summaries. The companion Obsidian plugin handles automatic extraction; this skill is for agent-driven pre-population only.
+description: Concept-map sidecar schema and heuristics for optional agent-curated Visual Notes graphs. The normal path is Obsidian plugin automatic extraction from watched markdown; this skill is for future pinned/curated sidecar workflows only.
 ---
 
 # Visual Notes (Claude Code skill)
@@ -11,22 +11,24 @@ description: Concept-map visualization for daily notes. Documents the sidecar JS
 
 ## What this skill is for
 
-When an AI agent is writing detailed session summaries to a daily note, the
-agent can also write a sidecar JSON describing the day's concepts as a
-graph. The Obsidian plugin renders that sidecar as a Cytoscape concept map
-inline in the daily note view.
+When an AI agent intentionally curates a graph, it can write a sidecar JSON
+describing a note's concepts as a graph. The Obsidian plugin renders that
+sidecar as a Cytoscape concept map inline in the note view.
+
+This is not the normal session-summary trigger. Session summaries should be
+created by the `obsidian-notes` skill using the AI session summary template,
+then extracted/rendered by the Obsidian Visual Notes plugin.
 
 The sidecar schema is defined in [`shared/schema.json`](../../../../shared/schema.json).
 
 ## Workflow (post-migration)
 
-1. After appending a session summary, read the daily note in full
+1. Read the target markdown note
 2. Design a graph: nodes for major concepts, edges for relationships
 3. Apply the design heuristics (see references)
-4. Write the sidecar JSON next to the daily note as
-   `{date}-overview.json`
-5. The Obsidian plugin's file watcher will pick up the change and render
-   the visual
+4. Write the sidecar JSON next to the note as `{note-basename}-overview.json`
+5. Set `_pinned: true` only when the agent is deliberately claiming ownership
+6. The Obsidian plugin renders the visual from the sidecar
 
 ## Heuristics (summary)
 

--- a/plugins/obsidian-plugin/README.md
+++ b/plugins/obsidian-plugin/README.md
@@ -1,9 +1,9 @@
 # Visual Notes — Obsidian plugin
 
-The primary artifact of the [Visual Notes](../..) project. Watches daily
-notes in a configured folder, calls the Claude API to extract a concept-map
-graph from the markdown, applies a deterministic layout pass, and renders an
-interactive Cytoscape visual at the top of the rendered note view.
+The primary artifact of the [Visual Notes](../..) project. Watches configured
+markdown folders, calls the Claude API to extract a concept-map graph, applies a
+deterministic layout pass, writes a sibling JSON sidecar, and renders an
+interactive Cytoscape visual in Obsidian.
 
 ## Status
 
@@ -67,7 +67,7 @@ After install, open Settings → Visual Notes:
 | Setting | What it does |
 |---|---|
 | **Anthropic API key** | Required. Get one at [console.anthropic.com](https://console.anthropic.com). Stored in plaintext `data.json` for this first pass. |
-| **Watched folders** | A list of folders containing daily notes. **Empty by default** — add at least one for the plugin to do anything. Subfolders are searched recursively. Add multiple folders if you keep separate work/personal/project journals (e.g., `Captains Log`, `0 Daily ADHD Brain Logs`, `Projects/visual-notes/Journal`). Each folder produces its own sidecars in-place; same model, same prompt, same schema across all watched folders. |
+| **Watched folders** | A list of folders containing notes to visualize. **Empty by default** — add at least one for the plugin to do anything. Subfolders are searched recursively. Add daily folders and AI session folders as needed (e.g., `0 Daily ADHD Brain Logs`, `0 Profisee/Captains Log`, `0 AI Sessions`, `0 Profisee/AI Sessions`). Each folder produces sidecars in-place; same model, same prompt, same schema across all watched folders. |
 | **Debounce (ms)** | How long to wait after the last save before extracting. Default: 1500ms. |
 | **Model** | `claude-haiku-4-5` (default, ~$0.006/extraction) or `claude-sonnet-4-6` (~$0.02). |
 | **Use Daily Context** | When the `daily-context` plugin is available, extract from structured daily sources instead of raw note markdown. |
@@ -79,6 +79,8 @@ wait for the prompt-override field in a later release.
 
 ## How it works
 
+The plugin is standalone: it can extract from any watched markdown note.
+
 ```mermaid
 sequenceDiagram
     participant User
@@ -86,15 +88,31 @@ sequenceDiagram
     participant Plugin
     participant API as Claude API
 
-    User->>Obsidian: save daily note
+    User->>Obsidian: save or manually extract a watched note
     Obsidian->>Plugin: vault.on('modify')
+    Plugin->>Plugin: choose raw note or Daily Context source
     Plugin->>Plugin: debounce + hash check
     Plugin->>API: requestUrl /v1/messages
     API-->>Plugin: structured JSON (Zod-validated)
-    Plugin->>Obsidian: write {date}-overview.json
+    Plugin->>Obsidian: write {note-basename}-overview.json
     Obsidian->>Plugin: trigger MarkdownPostProcessor
-    Plugin->>User: render Cytoscape inline
+    Plugin->>User: render Cytoscape inline or in visual-notes block
 ```
+
+Daily Context auto-mode applies only to date-named daily notes such as
+`20260517.md` or `2026-05-17.md`. Other watched markdown files use raw-note
+extraction by default, even if their path contains a date. That keeps optional
+workflows such as AI session summaries from accidentally ingesting every source
+attached to the same day.
+
+To reserve a stable visual location in any note or template, add:
+
+````markdown
+## Session Visual
+
+```visual-notes
+```
+````
 
 See the architecture overview in [`../../README.md`](../../README.md) and the
 future-facing notes in [`../../docs/design.md`](../../docs/design.md).
@@ -134,9 +152,14 @@ redacted metadata and never commits prompts, source text, or generated graphs.
 ## Sources of content
 
 By default, the plugin extracts from the active note. When Daily Context is
-enabled and available, it extracts from that provider's structured source list
-instead. The explicit **Extract from current note using Daily Context** command
-requires the provider and does not fall back to raw markdown.
+enabled and available for a date-like daily note, it extracts from that
+provider's structured source list instead. The explicit **Extract from current
+note using Daily Context** command requires the provider and does not fall back
+to raw markdown.
+
+Date-named daily notes can use Daily Context in automatic mode. Other watched
+notes use raw-note mode unless the user explicitly runs the Daily Context
+command on a compatible date-named note.
 
 Raw-note mode sees **everything** in the daily note:
 - AI session summaries written by Claude Code, OpenCode, Copilot, etc.

--- a/plugins/obsidian-plugin/README.md
+++ b/plugins/obsidian-plugin/README.md
@@ -95,8 +95,8 @@ sequenceDiagram
     Plugin->>API: requestUrl /v1/messages
     API-->>Plugin: structured JSON (Zod-validated)
     Plugin->>Obsidian: write {note-basename}-overview.json
-    Obsidian->>Plugin: trigger MarkdownPostProcessor
-    Plugin->>User: render Cytoscape inline or in visual-notes block
+    Obsidian->>Plugin: render ```visual-notes codeblock
+    Plugin->>User: mount Cytoscape inside the codeblock host
 ```
 
 Daily Context auto-mode applies only to date-named daily notes such as

--- a/plugins/obsidian-plugin/prompts/extract-graph.md
+++ b/plugins/obsidian-plugin/prompts/extract-graph.md
@@ -50,10 +50,10 @@ The most-connected nodes are the day's central themes. Peripheral nodes
 get one or two edges. If everything has the same fan-out, you flattened
 the structure — re-read for the actual hub.
 
-### 3. Max 30 nodes — MUST cluster past that
+### 3. Prefer 8–18 nodes; max 30 nodes — MUST cluster past that
 
-Past ~30 nodes the visual becomes unreadable; past 50 the schema
-rejects it. **Cluster aggressively:**
+For ordinary notes, prefer 8–18 nodes. Past ~30 nodes the visual becomes
+unreadable; past 50 the schema rejects it. **Cluster aggressively:**
 
 - If any single section has ≥10 distinct items, group them into ONE
   cluster node, don't enumerate.

--- a/plugins/obsidian-plugin/src/anthropic.ts
+++ b/plugins/obsidian-plugin/src/anthropic.ts
@@ -1,0 +1,117 @@
+export type AnthropicFailureKind =
+  | "authentication"
+  | "rate-limit"
+  | "usage-limit"
+  | "input-too-large"
+  | "output-too-large"
+  | "bad-request"
+  | "server"
+  | "unknown";
+
+export interface AnthropicErrorDetails {
+  type?: string;
+  message?: string;
+}
+
+export function validateAnthropicApiKey(apiKey: string): string | null {
+  const trimmed = apiKey.trim();
+  if (!trimmed) {
+    return "add your Anthropic API key in Settings.";
+  }
+
+  if (trimmed.includes("…") || trimmed.includes("...")) {
+    return "API key looks redacted; paste the full Anthropic key in Settings.";
+  }
+
+  if (!trimmed.startsWith("sk-ant-")) {
+    return "API key should start with sk-ant-. Check Settings -> Visual Notes.";
+  }
+
+  if (trimmed.length < 40) {
+    return "API key appears incomplete. Check Settings -> Visual Notes.";
+  }
+
+  return null;
+}
+
+export function classifyAnthropicFailure(
+  status: number | undefined,
+  details: AnthropicErrorDetails = {},
+): AnthropicFailureKind {
+  const type = details.type ?? "";
+  const message = (details.message ?? "").toLowerCase();
+
+  if (status === 401 || type === "authentication_error") {
+    return "authentication";
+  }
+
+  if (status === 429 || type === "rate_limit_error") {
+    return "rate-limit";
+  }
+
+  if (
+    message.includes("usage limit") ||
+    message.includes("usage limits") ||
+    message.includes("credit balance")
+  ) {
+    return "usage-limit";
+  }
+
+  if (
+    status === 413 ||
+    message.includes("prompt is too long") ||
+    message.includes("context length") ||
+    message.includes("maximum context") ||
+    message.includes("input tokens")
+  ) {
+    return "input-too-large";
+  }
+
+  if (message.includes("max_tokens") || message.includes("output tokens")) {
+    return "output-too-large";
+  }
+
+  if (status === 400 || type === "invalid_request_error") {
+    return "bad-request";
+  }
+
+  if (status !== undefined && status >= 500) {
+    return "server";
+  }
+
+  return "unknown";
+}
+
+export function retryAfterSeconds(headers: Record<string, string> | undefined): number | undefined {
+  const raw = headerValue(headers, "retry-after");
+  if (!raw) {
+    return undefined;
+  }
+
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds;
+  }
+
+  const dateMs = Date.parse(raw);
+  if (!Number.isFinite(dateMs)) {
+    return undefined;
+  }
+
+  return Math.max(0, Math.ceil((dateMs - Date.now()) / 1000));
+}
+
+function headerValue(headers: Record<string, string> | undefined, name: string): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  const lowerName = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lowerName) {
+      return value;
+    }
+  }
+
+  return undefined;
+}

--- a/plugins/obsidian-plugin/src/anthropic.ts
+++ b/plugins/obsidian-plugin/src/anthropic.ts
@@ -13,6 +13,11 @@ export interface AnthropicErrorDetails {
   message?: string;
 }
 
+// Anthropic keys are well over 40 chars (typically ~108); this is a minimum
+// plausibility floor that catches obvious paste failures without hard-coding
+// the current length (which Anthropic may change).
+const MIN_PLAUSIBLE_KEY_LENGTH = 40;
+
 export function validateAnthropicApiKey(apiKey: string): string | null {
   const trimmed = apiKey.trim();
   if (!trimmed) {
@@ -27,7 +32,7 @@ export function validateAnthropicApiKey(apiKey: string): string | null {
     return "API key should start with sk-ant-. Check Settings -> Visual Notes.";
   }
 
-  if (trimmed.length < 40) {
+  if (trimmed.length < MIN_PLAUSIBLE_KEY_LENGTH) {
     return "API key appears incomplete. Check Settings -> Visual Notes.";
   }
 

--- a/plugins/obsidian-plugin/src/anthropic.ts
+++ b/plugins/obsidian-plugin/src/anthropic.ts
@@ -13,9 +13,6 @@ export interface AnthropicErrorDetails {
   message?: string;
 }
 
-// Anthropic keys are well over 40 chars (typically ~108); this is a minimum
-// plausibility floor that catches obvious paste failures without hard-coding
-// the current length (which Anthropic may change).
 const MIN_PLAUSIBLE_KEY_LENGTH = 40;
 
 export function validateAnthropicApiKey(apiKey: string): string | null {

--- a/plugins/obsidian-plugin/src/daily-context.ts
+++ b/plugins/obsidian-plugin/src/daily-context.ts
@@ -89,7 +89,7 @@ export function getDailyContextApi(app: unknown): DailyContextApi | null {
 export function normalizeDailyContextDateFromPath(path: string): string | null {
   const normalizedPath = path.replace(/\\/g, "/");
   const basename = normalizedPath.split("/").pop()?.replace(/\.md$/iu, "") ?? normalizedPath;
-  return normalizeDateMatch(basename) ?? normalizeDateMatch(normalizedPath);
+  return normalizeWholeDate(basename);
 }
 
 export function buildDailyContextExtractionInput(
@@ -216,6 +216,14 @@ function normalizeDateMatch(value: string): string | null {
   const compact = value.match(/(?:^|[^\d])(\d{4})(\d{2})(\d{2})(?:[^\d]|$)/u);
   if (compact) {
     return `${compact[1]}-${compact[2]}-${compact[3]}`;
+  }
+
+  return null;
+}
+
+function normalizeWholeDate(value: string): string | null {
+  if (/^\d{4}-\d{2}-\d{2}$/u.test(value) || /^\d{8}$/u.test(value)) {
+    return normalizeDateMatch(value);
   }
 
   return null;

--- a/plugins/obsidian-plugin/src/extractor.ts
+++ b/plugins/obsidian-plugin/src/extractor.ts
@@ -2,13 +2,18 @@ import { requestUrl } from "obsidian";
 import { z } from "zod";
 import EXTRACT_GRAPH_PROMPT from "../prompts/extract-graph.md";
 import sharedSidecarSchema from "../../../shared/schema.json";
+import {
+  classifyAnthropicFailure,
+  retryAfterSeconds,
+  type AnthropicFailureKind,
+} from "./anthropic";
 import { sidecarSchema, type VisualNotesSidecar } from "./schema";
 import type { MarkdownSectionSummary } from "./sections";
 import { createExtractionUsage, type ExtractionUsage } from "./usage";
 
 const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
-const MAX_OUTPUT_TOKENS = 4096;
+const MAX_OUTPUT_TOKENS = 8192;
 const MAX_VALIDATION_ATTEMPTS = 2;
 
 const anthropicMessagesResponseSchema = z
@@ -68,6 +73,8 @@ export class AnthropicExtractionError extends Error {
   constructor(
     message: string,
     readonly status?: number,
+    readonly failureKind: AnthropicFailureKind = classifyAnthropicFailure(status),
+    readonly retryAfter?: number,
   ) {
     super(message);
     this.name = "AnthropicExtractionError";
@@ -132,9 +139,12 @@ export async function extractGraphFromAnthropic(
     });
 
     if (response.status !== 200) {
+      const apiError = parseAnthropicError(response.text);
       throw new AnthropicExtractionError(
-        `Anthropic API returned HTTP ${response.status}: ${formatAnthropicError(response.text)}`,
+        `Anthropic API returned HTTP ${response.status}: ${formatAnthropicError(apiError)}`,
         response.status,
+        classifyAnthropicFailure(response.status, apiError),
+        retryAfterSeconds(response.headers),
       );
     }
 
@@ -142,6 +152,8 @@ export async function extractGraphFromAnthropic(
     if (parsedResponse.stop_reason === "max_tokens") {
       throw new AnthropicExtractionError(
         `Anthropic response hit the ${MAX_OUTPUT_TOKENS} token limit before producing a complete graph.`,
+        undefined,
+        "output-too-large",
       );
     }
 
@@ -262,15 +274,27 @@ function summarizeContentTypes(content: unknown[]): string {
   return types.length > 0 ? types.join(", ") : "none";
 }
 
-function formatAnthropicError(text: string): string {
+function parseAnthropicError(text: string): { type?: string; message?: string; raw: string } {
   const value = tryParseJson(text);
   const parsed = anthropicToolResponseSchema.safeParse(value);
-  if (parsed.success && parsed.data.error?.message) {
-    const type = parsed.data.error.type ? `${parsed.data.error.type}: ` : "";
-    return `${type}${parsed.data.error.message}`;
+  if (parsed.success && parsed.data.error) {
+    return {
+      type: parsed.data.error.type,
+      message: parsed.data.error.message,
+      raw: text,
+    };
   }
 
-  return truncate(text);
+  return { raw: text };
+}
+
+function formatAnthropicError(error: { type?: string; message?: string; raw: string }): string {
+  if (error.message) {
+    const type = error.type ? `${error.type}: ` : "";
+    return `${type}${error.message}`;
+  }
+
+  return truncate(error.raw);
 }
 
 function formatZodError(error: z.ZodError): string {

--- a/plugins/obsidian-plugin/src/main.ts
+++ b/plugins/obsidian-plugin/src/main.ts
@@ -101,17 +101,10 @@ export default class VisualNotesPlugin extends Plugin {
       return;
     }
 
-    const existingContainer = el.querySelector(".visual-notes-codeblock-container");
-    if (existingContainer instanceof HTMLElement) {
-      return;
-    }
-
     try {
       const container = document.createElement("div");
       container.classList.add("visual-notes-container", "visual-notes-codeblock-container");
       container.dataset.visualNotesSourcePath = ctx.sourcePath;
-      // Build the render child BEFORE we mutate `el`, so a constructor failure
-      // doesn't leave the codeblock wiped.
       const child = new VisualNotesRenderChild(container, this, ctx.sourcePath, {
         removeContainerOnUnload: false,
         removeDuplicates: false,

--- a/plugins/obsidian-plugin/src/main.ts
+++ b/plugins/obsidian-plugin/src/main.ts
@@ -107,18 +107,18 @@ export default class VisualNotesPlugin extends Plugin {
     }
 
     try {
-      el.replaceChildren();
-      el.classList.add("visual-notes-codeblock-host");
       const container = document.createElement("div");
-      container.className = "visual-notes-container visual-notes-codeblock-container";
+      container.classList.add("visual-notes-container", "visual-notes-codeblock-container");
       container.dataset.visualNotesSourcePath = ctx.sourcePath;
-      el.appendChild(container);
-      ctx.addChild(
-        new VisualNotesRenderChild(container, this, ctx.sourcePath, {
-          removeContainerOnUnload: false,
-          removeDuplicates: false,
-        }),
-      );
+      // Build the render child BEFORE we mutate `el`, so a constructor failure
+      // doesn't leave the codeblock wiped.
+      const child = new VisualNotesRenderChild(container, this, ctx.sourcePath, {
+        removeContainerOnUnload: false,
+        removeDuplicates: false,
+      });
+      el.replaceChildren(container);
+      el.classList.add("visual-notes-codeblock-host");
+      ctx.addChild(child);
     } catch (error) {
       this.log("error", "Failed to mount visual-notes code block.", { sourcePath: ctx.sourcePath, error });
     }

--- a/plugins/obsidian-plugin/src/main.ts
+++ b/plugins/obsidian-plugin/src/main.ts
@@ -6,6 +6,7 @@ import {
   Plugin,
   TFile,
   normalizePath,
+  type MarkdownPostProcessorContext,
 } from "obsidian";
 import {
   buildDailyContextExtractionInput,
@@ -14,6 +15,7 @@ import {
   normalizeDailyContextDateFromPath,
   type PreparedDailyContextExtraction,
 } from "./daily-context";
+import { validateAnthropicApiKey } from "./anthropic";
 import { AnthropicExtractionError, extractGraphFromAnthropic } from "./extractor";
 import { estimateTokens, hashMarkdownSections, semanticMarkdownHash, sha256Hash } from "./hash";
 import { applyDeterministicLayout } from "./layout";
@@ -44,11 +46,12 @@ const MOUNT_RETRY_LIMIT = 30;
 const MOUNT_RETRY_DELAY_MS = 100;
 
 type VisualNotesViewMode = "preview" | "source";
+type ExtractionSourceMode = "auto" | "daily-context";
 
 interface ExtractionOptions {
   force: boolean;
   manual: boolean;
-  sourceMode?: "auto" | "daily-context";
+  sourceMode?: ExtractionSourceMode;
 }
 
 interface PreparedExtractionInput {
@@ -88,8 +91,27 @@ export default class VisualNotesPlugin extends Plugin {
 
     await this.noticeMissingWatchedFolders();
     this.registerCommands();
+    this.registerMarkdownCodeBlockProcessor("visual-notes", (_source, el, ctx) => {
+      this.mountVisualNotesCodeBlock(el, ctx);
+    });
     this.registerMarkdownPostProcessor((el, ctx) => {
       if (!ctx.sourcePath.endsWith(".md")) {
+        return;
+      }
+
+      const renderedBlocks = Array.from(el.querySelectorAll(".block-language-visual-notes")).filter(
+        (block): block is HTMLElement => block instanceof HTMLElement,
+      );
+      const visualBlocks =
+        renderedBlocks.length > 0
+          ? renderedBlocks
+          : Array.from(
+              el.querySelectorAll(".cm-lang-visual-notes, pre > code.language-visual-notes, code.language-visual-notes"),
+            ).filter((block): block is HTMLElement => block instanceof HTMLElement);
+      if (visualBlocks.length > 0) {
+        visualBlocks.forEach((block) => {
+          this.mountVisualNotesCodeBlock(block, ctx);
+        });
         return;
       }
 
@@ -134,6 +156,34 @@ export default class VisualNotesPlugin extends Plugin {
     this.registerInterval(window.setInterval(() => this.queueActiveVisualNotesMount(), 1_000));
 
     window.setTimeout(() => this.queueActiveVisualNotesMount(), 0);
+  }
+
+  private mountVisualNotesCodeBlock(el: HTMLElement, ctx: MarkdownPostProcessorContext): void {
+    if (!ctx.sourcePath.endsWith(".md")) {
+      return;
+    }
+
+    const existingContainer = el.querySelector(".visual-notes-codeblock-container");
+    if (existingContainer instanceof HTMLElement) {
+      return;
+    }
+
+    try {
+      el.replaceChildren();
+      el.classList.add("visual-notes-codeblock-host");
+      const container = document.createElement("div");
+      container.className = "visual-notes-container visual-notes-codeblock-container";
+      container.dataset.visualNotesSourcePath = ctx.sourcePath;
+      el.appendChild(container);
+      ctx.addChild(
+        new VisualNotesRenderChild(container, this, ctx.sourcePath, {
+          removeContainerOnUnload: false,
+          removeDuplicates: false,
+        }),
+      );
+    } catch (error) {
+      this.log("error", "Failed to mount visual-notes code block.", { sourcePath: ctx.sourcePath, error });
+    }
   }
 
   onunload(): void {
@@ -248,11 +298,16 @@ export default class VisualNotesPlugin extends Plugin {
     this.pendingMountSourcePaths.add(sourcePath);
     window.setTimeout(() => {
       this.pendingMountSourcePaths.delete(sourcePath);
-      this.mountVisualNotesForSource(sourcePath);
+      void this.mountVisualNotesForSource(sourcePath);
     }, 0);
   }
 
-  private mountVisualNotesForSource(sourcePath: string, attempt = 0): void {
+  private async mountVisualNotesForSource(sourcePath: string, attempt = 0): Promise<void> {
+    if (await this.sourceHasExplicitVisualNotesBlock(sourcePath)) {
+      this.clearActiveRenderChild();
+      return;
+    }
+
     const activeFile = this.app.workspace.getActiveFile();
     if (!(activeFile instanceof TFile) || activeFile.path !== sourcePath) {
       return;
@@ -269,7 +324,7 @@ export default class VisualNotesPlugin extends Plugin {
     if (!(mountTarget instanceof HTMLElement)) {
       if (attempt < MOUNT_RETRY_LIMIT) {
         window.setTimeout(
-          () => this.mountVisualNotesForSource(sourcePath, attempt + 1),
+          () => void this.mountVisualNotesForSource(sourcePath, attempt + 1),
           MOUNT_RETRY_DELAY_MS,
         );
       }
@@ -282,6 +337,11 @@ export default class VisualNotesPlugin extends Plugin {
       this.activeRenderMode === mode &&
       this.activeRenderChild.containerEl.parentElement === mountTarget
     ) {
+      return;
+    }
+
+    if (mode === "preview" && this.hasCodeblockContainerForSource(sourcePath)) {
+      this.clearActiveRenderChild();
       return;
     }
 
@@ -333,6 +393,24 @@ export default class VisualNotesPlugin extends Plugin {
     this.activeRenderChild = null;
     this.activeRenderSourcePath = null;
     this.activeRenderMode = null;
+  }
+
+  private hasCodeblockContainerForSource(sourcePath: string): boolean {
+    return (
+      document.querySelector(
+        `.visual-notes-codeblock-container[data-visual-notes-source-path="${cssEscape(sourcePath)}"]`,
+      ) !== null
+    );
+  }
+
+  private async sourceHasExplicitVisualNotesBlock(sourcePath: string): Promise<boolean> {
+    const file = this.app.vault.getAbstractFileByPath(sourcePath);
+    if (!(file instanceof TFile)) {
+      return false;
+    }
+
+    const markdown = await this.app.vault.read(file);
+    return /```visual-notes(?:\s|$)/u.test(markdown);
   }
 
   private withActiveMarkdownFile(
@@ -403,8 +481,9 @@ export default class VisualNotesPlugin extends Plugin {
   }
 
   private async extractFile(file: TFile, options: ExtractionOptions): Promise<void> {
-    if (!this.settings.anthropicApiKey) {
-      new Notice("Visual Notes: add your Anthropic API key in Settings.");
+    const apiKeyProblem = validateAnthropicApiKey(this.settings.anthropicApiKey);
+    if (apiKeyProblem) {
+      new Notice(`Visual Notes: ${apiKeyProblem}`, 8000);
       this.updateStatusBar();
       return;
     }
@@ -548,7 +627,8 @@ export default class VisualNotesPlugin extends Plugin {
     options: ExtractionOptions,
   ): Promise<PreparedExtractionInput | null> {
     const rawHash = await sha256Hash(rawMarkdown);
-    const dailyContext = await this.prepareDailyContextExtraction(file, options.sourceMode ?? "auto");
+    const sourceMode = options.sourceMode ?? "auto";
+    const dailyContext = await this.prepareDailyContextExtraction(file, sourceMode);
     if (dailyContext) {
       return {
         ...dailyContext,
@@ -556,7 +636,7 @@ export default class VisualNotesPlugin extends Plugin {
       };
     }
 
-    if (options.sourceMode === "daily-context") {
+    if (sourceMode === "daily-context") {
       return null;
     }
 
@@ -728,6 +808,12 @@ export default class VisualNotesPlugin extends Plugin {
       return;
     }
 
+    if (validateAnthropicApiKey(this.settings.anthropicApiKey)) {
+      this.statusBarEl.setText("Visual Notes: check API key");
+      this.statusBarEl.toggleClass("mod-error", true);
+      return;
+    }
+
     if (this.settings.watchedFolders.length === 0) {
       this.statusBarEl.setText("Visual Notes: add watched folder");
       this.statusBarEl.toggleClass("mod-error", true);
@@ -746,14 +832,39 @@ export default class VisualNotesPlugin extends Plugin {
 
   private handleExtractionError(error: unknown): void {
     if (error instanceof AnthropicExtractionError) {
-      this.log("error", error.message, { status: error.status });
-      if (error.status === 401) {
-        new Notice("Visual Notes: API key invalid. Open Settings -> Visual Notes.", 8000);
-        return;
+      this.log("error", error.message, {
+        status: error.status,
+        failureKind: error.failureKind,
+        retryAfter: error.retryAfter,
+      });
+      switch (error.failureKind) {
+        case "authentication":
+          new Notice("Visual Notes: API key invalid. Open Settings -> Visual Notes.", 8000);
+          return;
+        case "rate-limit": {
+          const retryText = error.retryAfter ? ` Try again in ~${error.retryAfter}s.` : "";
+          new Notice(`Visual Notes: Anthropic rate limit hit.${retryText}`, 8000);
+          return;
+        }
+        case "usage-limit":
+          new Notice("Visual Notes: Anthropic API usage limit reached. Check billing/limits.", 8000);
+          return;
+        case "input-too-large":
+          new Notice("Visual Notes: extraction input is too large. Narrow Daily Context or split the note.", 8000);
+          return;
+        case "output-too-large":
+          new Notice("Visual Notes: graph response hit the output token limit. Split the note or reduce scope.", 8000);
+          return;
+        case "bad-request":
+          new Notice("Visual Notes: Anthropic rejected the request. Check model/settings; see console.", 8000);
+          return;
+        case "server":
+          new Notice("Visual Notes: Anthropic service error. Try again later.", 8000);
+          return;
+        case "unknown":
+          new Notice(`Visual Notes: extraction failed (${error.status ?? "network"}). See console.`);
+          return;
       }
-
-      new Notice(`Visual Notes: extraction failed (${error.status ?? "network"}). See console.`);
-      return;
     }
 
     this.log("error", "Extraction failed.", error);

--- a/plugins/obsidian-plugin/src/main.ts
+++ b/plugins/obsidian-plugin/src/main.ts
@@ -1,7 +1,6 @@
 import {
   debounce,
   Events,
-  MarkdownView,
   Notice,
   Plugin,
   TFile,
@@ -42,10 +41,7 @@ import { addExtractionUsage } from "./usage";
 const PRODUCER_ID = "obsidian-plugin@0.1.0";
 const MAX_INPUT_TOKENS = 100_000;
 const FORCE_REGENERATE_COOLDOWN_MS = 30_000;
-const MOUNT_RETRY_LIMIT = 30;
-const MOUNT_RETRY_DELAY_MS = 100;
 
-type VisualNotesViewMode = "preview" | "source";
 type ExtractionSourceMode = "auto" | "daily-context";
 
 interface ExtractionOptions {
@@ -71,10 +67,6 @@ export default class VisualNotesPlugin extends Plugin {
   private readonly forceRegenerateCooldowns = new Map<string, number>();
   private readonly activeExtractionPaths = new Set<string>();
   private readonly pendingExtractionPaths = new Set<string>();
-  private readonly pendingMountSourcePaths = new Set<string>();
-  private activeRenderChild: VisualNotesRenderChild | null = null;
-  private activeRenderSourcePath: string | null = null;
-  private activeRenderMode: VisualNotesViewMode | null = null;
   private statusBarEl: HTMLElement | null = null;
   private activeExtractions = 0;
 
@@ -94,29 +86,6 @@ export default class VisualNotesPlugin extends Plugin {
     this.registerMarkdownCodeBlockProcessor("visual-notes", (_source, el, ctx) => {
       this.mountVisualNotesCodeBlock(el, ctx);
     });
-    this.registerMarkdownPostProcessor((el, ctx) => {
-      if (!ctx.sourcePath.endsWith(".md")) {
-        return;
-      }
-
-      const renderedBlocks = Array.from(el.querySelectorAll(".block-language-visual-notes")).filter(
-        (block): block is HTMLElement => block instanceof HTMLElement,
-      );
-      const visualBlocks =
-        renderedBlocks.length > 0
-          ? renderedBlocks
-          : Array.from(
-              el.querySelectorAll(".cm-lang-visual-notes, pre > code.language-visual-notes, code.language-visual-notes"),
-            ).filter((block): block is HTMLElement => block instanceof HTMLElement);
-      if (visualBlocks.length > 0) {
-        visualBlocks.forEach((block) => {
-          this.mountVisualNotesCodeBlock(block, ctx);
-        });
-        return;
-      }
-
-      this.queueVisualNotesMount(ctx.sourcePath);
-    });
 
     this.registerEvent(
       this.app.vault.on("modify", (file) => {
@@ -125,37 +94,6 @@ export default class VisualNotesPlugin extends Plugin {
         }
       }),
     );
-
-    this.registerEvent(
-      this.app.workspace.on("active-leaf-change", (leaf) => {
-        if (leaf?.view instanceof MarkdownView && leaf.view.file) {
-          this.queueVisualNotesMount(leaf.view.file.path);
-          return;
-        }
-
-        this.clearActiveRenderChild();
-      }),
-    );
-
-    this.registerEvent(
-      this.app.workspace.on("file-open", (file) => {
-        if (file instanceof TFile && file.extension === "md") {
-          this.queueVisualNotesMount(file.path);
-          return;
-        }
-
-        this.clearActiveRenderChild();
-      }),
-    );
-
-    this.registerEvent(
-      this.app.workspace.on("layout-change", () => {
-        this.queueActiveVisualNotesMount();
-      }),
-    );
-    this.registerInterval(window.setInterval(() => this.queueActiveVisualNotesMount(), 1_000));
-
-    window.setTimeout(() => this.queueActiveVisualNotesMount(), 0);
   }
 
   private mountVisualNotesCodeBlock(el: HTMLElement, ctx: MarkdownPostProcessorContext): void {
@@ -189,8 +127,6 @@ export default class VisualNotesPlugin extends Plugin {
   onunload(): void {
     this.debounceTimers.forEach((timer) => timer.cancel());
     this.debounceTimers.clear();
-    this.pendingMountSourcePaths.clear();
-    this.clearActiveRenderChild();
   }
 
   async loadSettings(): Promise<void> {
@@ -274,143 +210,6 @@ export default class VisualNotesPlugin extends Plugin {
         this.deleteSidecar(file),
       ),
     });
-  }
-
-  private queueActiveVisualNotesMount(): void {
-    const activeFile = this.app.workspace.getActiveFile();
-    if (!(activeFile instanceof TFile) || activeFile.extension !== "md") {
-      this.clearActiveRenderChild();
-      return;
-    }
-
-    this.queueVisualNotesMount(activeFile.path);
-  }
-
-  private queueVisualNotesMount(sourcePath: string): void {
-    if (!sourcePath.endsWith(".md")) {
-      return;
-    }
-
-    if (this.pendingMountSourcePaths.has(sourcePath)) {
-      return;
-    }
-
-    this.pendingMountSourcePaths.add(sourcePath);
-    window.setTimeout(() => {
-      this.pendingMountSourcePaths.delete(sourcePath);
-      void this.mountVisualNotesForSource(sourcePath);
-    }, 0);
-  }
-
-  private async mountVisualNotesForSource(sourcePath: string, attempt = 0): Promise<void> {
-    if (await this.sourceHasExplicitVisualNotesBlock(sourcePath)) {
-      this.clearActiveRenderChild();
-      return;
-    }
-
-    const activeFile = this.app.workspace.getActiveFile();
-    if (!(activeFile instanceof TFile) || activeFile.path !== sourcePath) {
-      return;
-    }
-
-    const leaf = this.getMarkdownLeafForPath(sourcePath);
-    if (!leaf || !(leaf.view instanceof MarkdownView)) {
-      return;
-    }
-
-    const mode = leaf.view.getMode() === "source" ? "source" : "preview";
-    const mountTarget = mode === "source" ? findSourceMountTarget(leaf.view) : findPreviewMountTarget(leaf.view);
-
-    if (!(mountTarget instanceof HTMLElement)) {
-      if (attempt < MOUNT_RETRY_LIMIT) {
-        window.setTimeout(
-          () => void this.mountVisualNotesForSource(sourcePath, attempt + 1),
-          MOUNT_RETRY_DELAY_MS,
-        );
-      }
-      return;
-    }
-
-    if (
-      this.activeRenderChild &&
-      this.activeRenderSourcePath === sourcePath &&
-      this.activeRenderMode === mode &&
-      this.activeRenderChild.containerEl.parentElement === mountTarget
-    ) {
-      return;
-    }
-
-    if (mode === "preview" && this.hasCodeblockContainerForSource(sourcePath)) {
-      this.clearActiveRenderChild();
-      return;
-    }
-
-    this.clearActiveRenderChild();
-
-    document
-      .querySelectorAll(`.visual-notes-container[data-visual-notes-source-path="${cssEscape(sourcePath)}"]`)
-      .forEach((container) => container.remove());
-
-    const container = document.createElement("div");
-    container.classList.add("visual-notes-container", `visual-notes-${mode}-container`);
-    container.dataset.visualNotesSourcePath = sourcePath;
-
-    if (mode === "source") {
-      const editor = mountTarget.querySelector(".cm-editor");
-      mountTarget.insertBefore(container, editor ?? mountTarget.firstChild);
-    } else {
-      const insertionTarget = findFrontmatterBoundary(mountTarget);
-      if (insertionTarget?.nextSibling) {
-        mountTarget.insertBefore(container, insertionTarget.nextSibling);
-      } else if (insertionTarget) {
-        mountTarget.appendChild(container);
-      } else {
-        mountTarget.prepend(container);
-      }
-    }
-
-    const child = new VisualNotesRenderChild(container, this, sourcePath);
-    this.addChild(child);
-    this.activeRenderChild = child;
-    this.activeRenderSourcePath = sourcePath;
-    this.activeRenderMode = mode;
-  }
-
-  private getMarkdownLeafForPath(sourcePath: string) {
-    return this.app.workspace
-      .getLeavesOfType("markdown")
-      .find((candidate) => {
-        const view = candidate.view;
-        return view instanceof MarkdownView && view.file?.path === sourcePath;
-      });
-  }
-
-  private clearActiveRenderChild(): void {
-    if (this.activeRenderChild) {
-      this.removeChild(this.activeRenderChild);
-    }
-
-    this.activeRenderChild = null;
-    this.activeRenderSourcePath = null;
-    this.activeRenderMode = null;
-  }
-
-  private hasCodeblockContainerForSource(sourcePath: string): boolean {
-    return (
-      document.querySelector(
-        `.visual-notes-codeblock-container[data-visual-notes-source-path="${cssEscape(sourcePath)}"]`,
-      ) !== null
-    );
-  }
-
-  private async sourceHasExplicitVisualNotesBlock(sourcePath: string): Promise<boolean> {
-    const file = this.app.vault.getAbstractFileByPath(sourcePath);
-    if (!(file instanceof TFile)) {
-      return false;
-    }
-
-    const markdown = await this.app.vault.read(file);
-    return /```visual-notes(?:\s|$)/u.test(markdown);
   }
 
   private withActiveMarkdownFile(
@@ -596,7 +395,6 @@ export default class VisualNotesPlugin extends Plugin {
 
       await this.app.vault.adapter.write(sidecarPath, `${JSON.stringify(stamped, null, 2)}\n`);
       this.sidecarEvents.trigger("changed", sidecarPath);
-      this.queueVisualNotesMount(file.path);
 
       const shouldShowFirstRunNotice = !this.settings.firstRunNoticeShown;
       if (shouldShowFirstRunNotice) {
@@ -900,32 +698,3 @@ function appendExtractionHistory(
   return [...(existingSidecar?._extractionHistory ?? []), entry].slice(-10);
 }
 
-function findPreviewMountTarget(view: MarkdownView): HTMLElement | null {
-  const section = view.containerEl.querySelector(
-    ".markdown-reading-view > .markdown-preview-view > .markdown-preview-sizer.markdown-preview-section",
-  );
-  return section instanceof HTMLElement ? section : null;
-}
-
-function findSourceMountTarget(view: MarkdownView): HTMLElement | null {
-  const sourceView = view.containerEl.querySelector(".markdown-source-view");
-  return sourceView instanceof HTMLElement ? sourceView : null;
-}
-
-function findFrontmatterBoundary(section: HTMLElement): Element | null {
-  const directChildren = Array.from(section.children);
-  const frontmatter = directChildren.find((child) =>
-    child.classList.contains("mod-header") ||
-    child.classList.contains("mod-frontmatter") ||
-    child.querySelector(".metadata-container") !== null,
-  );
-  if (frontmatter) {
-    return frontmatter;
-  }
-
-  return directChildren.find((child) => child.classList.contains("markdown-preview-pusher")) ?? null;
-}
-
-function cssEscape(value: string): string {
-  return value.replace(/["\\]/g, "\\$&");
-}

--- a/plugins/obsidian-plugin/src/renderer.ts
+++ b/plugins/obsidian-plugin/src/renderer.ts
@@ -14,15 +14,20 @@ export class VisualNotesRenderChild extends MarkdownRenderChild {
   private sidecarEventRef: EventRef | null = null;
   private readonly sidecarPath: string;
   private readonly sourcePath: string;
+  private readonly removeContainerOnUnload: boolean;
+  private readonly removeDuplicates: boolean;
 
   constructor(
     containerEl: HTMLElement,
     private readonly plugin: VisualNotesPlugin,
     sourcePath: string,
+    options: { removeContainerOnUnload?: boolean; removeDuplicates?: boolean } = {},
   ) {
     super(containerEl);
     this.sourcePath = sourcePath;
     this.sidecarPath = sidecarPathForMarkdownPath(sourcePath);
+    this.removeContainerOnUnload = options.removeContainerOnUnload ?? true;
+    this.removeDuplicates = options.removeDuplicates ?? true;
   }
 
   onload(): void {
@@ -46,7 +51,9 @@ export class VisualNotesRenderChild extends MarkdownRenderChild {
     ) {
       delete previewRoot.dataset.visualNotesSourcePath;
     }
-    this.containerEl.remove();
+    if (this.removeContainerOnUnload) {
+      this.containerEl.remove();
+    }
     this.sidecarEventRef = null;
   }
 
@@ -360,6 +367,10 @@ export class VisualNotesRenderChild extends MarkdownRenderChild {
   }
 
   private removeDuplicateContainersForSource(): void {
+    if (!this.removeDuplicates) {
+      return;
+    }
+
     Array.from(document.querySelectorAll(".visual-notes-container")).forEach((container) => {
       if (
         container !== this.containerEl &&

--- a/plugins/obsidian-plugin/src/renderer.ts
+++ b/plugins/obsidian-plugin/src/renderer.ts
@@ -43,14 +43,7 @@ export class VisualNotesRenderChild extends MarkdownRenderChild {
   }
 
   onunload(): void {
-    const previewRoot = this.containerEl.closest(".markdown-preview-view");
     this.destroyGraph();
-    if (
-      previewRoot instanceof HTMLElement &&
-      previewRoot.dataset.visualNotesSourcePath === this.sourcePath
-    ) {
-      delete previewRoot.dataset.visualNotesSourcePath;
-    }
     if (this.removeContainerOnUnload) {
       this.containerEl.remove();
     }

--- a/plugins/obsidian-plugin/styles.css
+++ b/plugins/obsidian-plugin/styles.css
@@ -4,11 +4,23 @@
   margin: 0 0 1rem;
   overflow: hidden;
   background: var(--background-primary);
+  box-sizing: border-box;
+  width: 100%;
 }
 
 .markdown-source-view > .visual-notes-source-container {
   flex: 0 0 auto;
   margin: 0 var(--file-margins) 1rem;
+  width: calc(100% - (2 * var(--file-margins)));
+}
+
+.visual-notes-codeblock-container {
+  margin: 1rem 0;
+}
+
+.visual-notes-codeblock-host {
+  display: block;
+  white-space: normal;
 }
 
 .visual-notes-header {

--- a/plugins/obsidian-plugin/styles.css
+++ b/plugins/obsidian-plugin/styles.css
@@ -145,8 +145,14 @@
 }
 
 .visual-notes-graph {
-  height: min(70vh, 660px);
-  min-height: 560px;
+  /* Block at the top of the note, not a viewport-filling slab.
+     - clamp() = always at least 200px (graph stays legible on small windows),
+       prefers ~35% of viewport (a reasonable "block, not screen" share),
+       capped at 420px (never dominates the editor pane in source mode).
+     - No min-height: previously 560px which, combined with .markdown-source-view
+       flex layout, squeezed the .cm-editor below it to ~0 and hid the note
+       contents entirely in edit mode. See issue #24 follow-up notes. */
+  height: clamp(200px, 35vh, 420px);
   width: 100%;
 }
 

--- a/plugins/obsidian-plugin/styles.css
+++ b/plugins/obsidian-plugin/styles.css
@@ -157,13 +157,6 @@
 }
 
 .visual-notes-graph {
-  /* Block at the top of the note, not a viewport-filling slab.
-     - clamp() = always at least 200px (graph stays legible on small windows),
-       prefers ~35% of viewport (a reasonable "block, not screen" share),
-       capped at 420px (never dominates the editor pane in source mode).
-     - No min-height: previously 560px which, combined with .markdown-source-view
-       flex layout, squeezed the .cm-editor below it to ~0 and hid the note
-       contents entirely in edit mode. See issue #24 follow-up notes. */
   height: clamp(200px, 35vh, 420px);
   width: 100%;
 }

--- a/plugins/obsidian-plugin/test/feature/anthropic.test.ts
+++ b/plugins/obsidian-plugin/test/feature/anthropic.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  classifyAnthropicFailure,
+  retryAfterSeconds,
+  validateAnthropicApiKey,
+} from "../../src/anthropic";
+
+test("validateAnthropicApiKey rejects missing redacted and incomplete keys before calling Anthropic", () => {
+  assert.equal(validateAnthropicApiKey(""), "add your Anthropic API key in Settings.");
+  assert.match(validateAnthropicApiKey("sk-ant-…work") ?? "", /redacted/u);
+  assert.match(validateAnthropicApiKey("sk-ant-short-key") ?? "", /incomplete/u);
+  assert.equal(validateAnthropicApiKey("sk-ant-api03-" + "a".repeat(80)), null);
+});
+
+test("classifyAnthropicFailure distinguishes auth rate limit and token failures", () => {
+  assert.equal(classifyAnthropicFailure(401, { type: "authentication_error" }), "authentication");
+  assert.equal(classifyAnthropicFailure(429, { type: "rate_limit_error" }), "rate-limit");
+  assert.equal(
+    classifyAnthropicFailure(400, { message: "You have reached your specified API usage limits." }),
+    "usage-limit",
+  );
+  assert.equal(classifyAnthropicFailure(413, { type: "invalid_request_error" }), "input-too-large");
+  assert.equal(
+    classifyAnthropicFailure(400, { message: "prompt is too long: exceeds maximum context length" }),
+    "input-too-large",
+  );
+  assert.equal(classifyAnthropicFailure(400, { message: "max_tokens exceeded" }), "output-too-large");
+  assert.equal(classifyAnthropicFailure(400, { type: "invalid_request_error" }), "bad-request");
+  assert.equal(classifyAnthropicFailure(500), "server");
+});
+
+test("retryAfterSeconds parses retry-after headers case-insensitively", () => {
+  assert.equal(retryAfterSeconds({ "Retry-After": "12" }), 12);
+  assert.equal(retryAfterSeconds({ "retry-after": "nope" }), undefined);
+});

--- a/plugins/obsidian-plugin/test/feature/anthropic.test.ts
+++ b/plugins/obsidian-plugin/test/feature/anthropic.test.ts
@@ -9,6 +9,7 @@ import {
 test("validateAnthropicApiKey rejects missing redacted and incomplete keys before calling Anthropic", () => {
   assert.equal(validateAnthropicApiKey(""), "add your Anthropic API key in Settings.");
   assert.match(validateAnthropicApiKey("sk-ant-…work") ?? "", /redacted/u);
+  assert.match(validateAnthropicApiKey("sk-ant-...work") ?? "", /redacted/u);
   assert.match(validateAnthropicApiKey("sk-ant-short-key") ?? "", /incomplete/u);
   assert.equal(validateAnthropicApiKey("sk-ant-api03-" + "a".repeat(80)), null);
 });

--- a/plugins/obsidian-plugin/test/feature/daily-context.test.ts
+++ b/plugins/obsidian-plugin/test/feature/daily-context.test.ts
@@ -39,6 +39,7 @@ test("getDailyContextApi discovers supported Daily Context plugin API", async ()
 test("normalizeDailyContextDateFromPath supports compact and dashed daily note names", () => {
   assert.equal(normalizeDailyContextDateFromPath("0 Daily ADHD Brain Logs/20260511.md"), "2026-05-11");
   assert.equal(normalizeDailyContextDateFromPath("Captains Log/2026-05-11.md"), "2026-05-11");
+  assert.equal(normalizeDailyContextDateFromPath("0 AI Sessions/2026-05-11 planning/2026-05-11 planning.md"), null);
   assert.equal(normalizeDailyContextDateFromPath("Notes/meeting.md"), null);
 });
 

--- a/plugins/obsidian-plugin/test/feature/daily-context.test.ts
+++ b/plugins/obsidian-plugin/test/feature/daily-context.test.ts
@@ -43,6 +43,21 @@ test("normalizeDailyContextDateFromPath supports compact and dashed daily note n
   assert.equal(normalizeDailyContextDateFromPath("Notes/meeting.md"), null);
 });
 
+test("normalizeDailyContextDateFromPath only matches strict basenames, never date patterns in folders", () => {
+  // Strict basename matches → return normalized date
+  assert.equal(normalizeDailyContextDateFromPath("2026-05-23.md"), "2026-05-23");
+  assert.equal(normalizeDailyContextDateFromPath("20260523.md"), "2026-05-23");
+
+  // Date is in a folder segment, not the basename → must return null
+  assert.equal(normalizeDailyContextDateFromPath("Daily/2026-05-23/notes.md"), null);
+
+  // No date at all → null
+  assert.equal(normalizeDailyContextDateFromPath("randomly-named.md"), null);
+
+  // Non-zero-padded single-digit month/day → null (must be strict 2-digit)
+  assert.equal(normalizeDailyContextDateFromPath("2026-5-23.md"), null);
+});
+
 test("buildDailyContextExtractionInput creates deterministic source sections and metadata", () => {
   const extraction = buildDailyContextExtractionInput(
     dailyContext({

--- a/plugins/obsidian-plugin/test/feature/renderer.test.ts
+++ b/plugins/obsidian-plugin/test/feature/renderer.test.ts
@@ -11,6 +11,7 @@ import { resolve } from "node:path";
 // substring checks intentionally — running `pnpm test:feature` alone (without
 // `pnpm validate`) still surfaces styling/lifecycle regressions.
 const rendererSource = readFileSync(resolve("src/renderer.ts"), "utf8");
+const mainSource = readFileSync(resolve("src/main.ts"), "utf8");
 
 describe("VisualNotesRenderChild — renderer source contract", () => {
   it("uses label-sized nodes with 11px / 500-weight text", () => {
@@ -113,6 +114,118 @@ describe("VisualNotesRenderChild — renderer source contract", () => {
       rendererSource,
       /normalizePath\(path\.replace\(\/\\\.md\$\/i, ""\) \+ "-overview\.json"\)/,
       "sidecarPathForMarkdownPath must strip .md and append -overview.json via Obsidian's normalizePath",
+    );
+  });
+});
+
+describe("VisualNotesRenderChild — render child options contract", () => {
+  it("accepts an options parameter in the constructor", () => {
+    assert.match(
+      rendererSource,
+      /options:\s*\{\s*removeContainerOnUnload\?:\s*boolean;\s*removeDuplicates\?:\s*boolean\s*\}\s*=\s*\{\}/,
+      "constructor must accept an options bag with removeContainerOnUnload and removeDuplicates",
+    );
+  });
+
+  it("defaults removeContainerOnUnload to true (legacy behavior)", () => {
+    assert.match(
+      rendererSource,
+      /this\.removeContainerOnUnload\s*=\s*options\.removeContainerOnUnload\s*\?\?\s*true/,
+      "removeContainerOnUnload must default to true to preserve legacy behavior",
+    );
+  });
+
+  it("defaults removeDuplicates to true (legacy behavior)", () => {
+    assert.match(
+      rendererSource,
+      /this\.removeDuplicates\s*=\s*options\.removeDuplicates\s*\?\?\s*true/,
+      "removeDuplicates must default to true to preserve legacy behavior",
+    );
+  });
+
+  it("gates containerEl.remove() in onunload behind removeContainerOnUnload", () => {
+    const onunloadMatch = rendererSource.match(/onunload\(\): void \{[\s\S]*?\n  \}/);
+    assert.ok(onunloadMatch, "renderer must define onunload");
+    const body = onunloadMatch[0];
+    assert.match(
+      body,
+      /if\s*\(\s*this\.removeContainerOnUnload\s*\)\s*\{[\s\S]*?this\.containerEl\.remove\(\)/,
+      "onunload must gate this.containerEl.remove() behind the removeContainerOnUnload flag",
+    );
+  });
+
+  it("early-returns from removeDuplicateContainersForSource when removeDuplicates is false", () => {
+    const fnMatch = rendererSource.match(
+      /private removeDuplicateContainersForSource\(\): void \{[\s\S]*?\n  \}/,
+    );
+    assert.ok(fnMatch, "renderer must define removeDuplicateContainersForSource");
+    const body = fnMatch[0];
+    assert.match(
+      body,
+      /if\s*\(!this\.removeDuplicates\)\s*\{\s*return;?\s*\}/,
+      "removeDuplicateContainersForSource must early-return when removeDuplicates is false",
+    );
+  });
+});
+
+describe("VisualNotesPlugin — main.ts mount strategy contract", () => {
+  it("registers a 'visual-notes' markdown codeblock processor", () => {
+    assert.match(
+      mainSource,
+      /registerMarkdownCodeBlockProcessor\(\s*"visual-notes"/,
+      "main.ts must register a markdown codeblock processor for 'visual-notes'",
+    );
+  });
+
+  it("defines mountVisualNotesCodeBlock as the codeblock mount entry point", () => {
+    assert.match(
+      mainSource,
+      /mountVisualNotesCodeBlock\s*\(/,
+      "main.ts must define mountVisualNotesCodeBlock",
+    );
+  });
+
+  it("creates VisualNotesRenderChild with removeContainerOnUnload: false and removeDuplicates: false", () => {
+    const mountMatch = mainSource.match(
+      /mountVisualNotesCodeBlock\([^)]*\):\s*void\s*\{[\s\S]*?\n  \}/,
+    );
+    assert.ok(mountMatch, "main.ts must define mountVisualNotesCodeBlock body");
+    const body = mountMatch[0];
+    assert.match(
+      body,
+      /new VisualNotesRenderChild\([\s\S]*?removeContainerOnUnload:\s*false[\s\S]*?removeDuplicates:\s*false[\s\S]*?\}\s*\)/,
+      "codeblock mount must opt out of legacy container-remove + dedupe behaviors",
+    );
+  });
+
+  it("references the codeblock host + container CSS classes", () => {
+    assert.match(
+      mainSource,
+      /visual-notes-codeblock-host/,
+      "main.ts must apply the codeblock host CSS class",
+    );
+    assert.match(
+      mainSource,
+      /visual-notes-codeblock-container/,
+      "main.ts must apply the codeblock container CSS class",
+    );
+  });
+
+  it("has removed the legacy auto-mount entry points (queueVisualNotesMount, mountVisualNotesForSource, setInterval)", () => {
+    assert.doesNotMatch(
+      mainSource,
+      /queueVisualNotesMount/,
+      "main.ts must no longer reference queueVisualNotesMount (legacy auto-mount removed)",
+    );
+    assert.doesNotMatch(
+      mainSource,
+      /mountVisualNotesForSource/,
+      "main.ts must no longer reference mountVisualNotesForSource (legacy auto-mount removed)",
+    );
+    assert.doesNotMatch(
+      mainSource,
+      /setInterval/,
+      "main.ts must no longer reference setInterval (legacy auto-mount polling removed)",
     );
   });
 });


### PR DESCRIPTION
## Summary

Resolves issue #24 by pivoting visual-notes from a manually-injected DOM auto-mount strategy to Obsidian's native codeblock processor (`registerMarkdownCodeBlockProcessor`). Users place a ` ```visual-notes ` fence where they want the graph; it renders correctly across reading view, live-preview, and source mode.

**Closes #24. Supersedes #28** (the WIP codeblock branch — its work is included in commit `8c2a289` and extended here).

## What was broken (issue #24's real cause)

Issue #24 was filed as a wheel-zoom trap, but the symptom was deeper:

- **Edit mode**: the auto-mounted `.visual-notes-container` was inserted as a flex sibling of `.cm-editor` inside `.markdown-source-view`. With `min-height: 560px`, the graph squeezed the editor to ~0 — only the graph was visible.
- **Reading mode**: a 1-second `setInterval` polling `queueActiveVisualNotesMount` re-injected the container at the current top whenever Obsidian's section virtualization rebuilt the preview sizer during scroll, making the graph "follow" the user between sections.

Wheel zoom was a misdiagnosis. The fix is the *mount strategy itself*, not wheel handling.

## Changes

### `accf298` — CSS height
`.visual-notes-graph` now `clamp(200px, 35vh, 420px)` with no `min-height`. Block at the top, not a viewport-filling slab.

### `8c2a289` — merge codeblock processor (carries 3 substantive changes from PR #28)

**(a) Codeblock processor.** `registerMarkdownCodeBlockProcessor("visual-notes", ...)` — the graph is rendered from the existing `*-overview.json` sidecar by `ctx.sourcePath`; codeblock body is ignored.

**(b) `MAX_OUTPUT_TOKENS` raised from 4096 → 8192 in `extractor.ts`.** ⚠️ **Billing-relevant**: ceiling on per-extraction output cost is now 2× what it was. Motivated by larger sidecars hitting the previous ceiling and producing truncated graphs. With Anthropic's current per-token pricing, a worst-case extraction now costs ~$0.012 instead of ~$0.006. Typical extractions are well below either ceiling and unaffected.

**(c) `normalizeDailyContextDateFromPath` tightened.** Previously fell back to scanning the full path for any `YYYY-MM-DD` pattern; now ONLY accepts strict `YYYY-MM-DD.md` or `YYYYMMDD.md` *filenames*. If you have daily notes in subfolders like `Daily/2026-05/notes.md`, daily-context auto-detection no longer applies to them — add the filename date or use the explicit daily-context source mode.

**(d) New `anthropic.ts` module.** Extracts API key validation, error classification, and retry-after parsing. Used by `extractor.ts` for richer error states (e.g. `usage-limit`, `input-too-large`, etc.) and by the status bar for proactive bad-key detection.

### `da1da56` — strip legacy auto-mount path
Removes the post-processor + setInterval + `.markdown-source-view` injection that was causing the bugs. Net **231 lines deleted, 0 added**.

Removed: `queueActiveVisualNotesMount`, `queueVisualNotesMount`, `mountVisualNotesForSource`, `clearActiveRenderChild`, `hasCodeblockContainerForSource`, `sourceHasExplicitVisualNotesBlock`, `getMarkdownLeafForPath`, `findPreviewMountTarget`, `findSourceMountTarget`, `findFrontmatterBoundary`, `cssEscape`, `VisualNotesViewMode`, `MOUNT_RETRY_LIMIT`, `MOUNT_RETRY_DELAY_MS`, 3 event handlers, setInterval polling, 4 state fields, `MarkdownView` import.

## Migration

User-side: any note that previously relied on auto-mount needs a ` ```visual-notes ` fence at the desired graph position. Daily-note templates should include the fence. The empty-body fence triggers rendering from the sidecar.

In the author's vault: personal notes (124 files: ADHD Brain Logs + 0 AI Sessions/* + templates) already migrated via filesystem-direct edits (no Obsidian auto-tagger triggered). Work notes (177 files under `0 Profisee/`) pending separate migration pass.

## Test plan

- [x] `pnpm test:feature` — 34/34 pass
- [x] `pnpm validate` — typecheck + layout-metrics + renderer-contract green
- [x] `pnpm build` — production bundle clean
- [x] Manual QA in vault: codeblock renders inline in reading view, scrolls as document flow, wheel-over-graph zooms (cytoscape default), wheel-elsewhere scrolls page

🤖 Generated with [Claude Code](https://claude.com/claude-code)